### PR TITLE
drop ? values

### DIFF
--- a/cldfbench_petersonsouthasia.py
+++ b/cldfbench_petersonsouthasia.py
@@ -96,13 +96,13 @@ class Dataset(BaseDataset):
             for j, v in enumerate(row.values()):
                 if j == 0:
                     lid = v
-                else:
+                elif v != '?':
                     pid = list(codes.keys())[j - 1]
                     args.writer.objects['ValueTable'].append({
                         'ID': '{0}-{1}'.format(lid, str(j)),
                         'Language_ID': lid,
                         'Parameter_ID': pid,
                         'Value': v,
-                        'Code_ID': '{0}-{1}'.format(pid, v) if v != '?' else None,
+                        'Code_ID': '{0}-{1}'.format(pid, v),
                         'Source': ['Peterson2017']
                     })


### PR DESCRIPTION
Removing `?` values that cause an exception on the webapp.

@xrotwang @haspelmath Do you remember if the `?` have any special meaning?  Like, are they just missing data or explicit markers for known unknowns?  If it's the latter I could also add a code for the `?` values (like *unknown*) instead of doing this.

As things are right now this data set contains parameters where some of the values have assigned codes and some don't, which trips up clld when it tries to plot them onto a map:

https://github.com/clld/clld/blob/55cee1e04f37ceb2bd0e325364edc4f1f9295185/src/clld/web/adapters/geojson.py#L185-L186
